### PR TITLE
Fixing defect for publicIPAddresses null Tag

### DIFF
--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/Resource.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/Resource.groovy
@@ -65,6 +65,13 @@ class PublicIpResource extends Resource{
     name = "[variables('publicIPAddressName')]"
     type = "Microsoft.Network/publicIPAddresses"
     location = "[parameters('location')]"
+    tags = [:]
+    tags.appName = description.application
+    tags.stack = description.stack
+    tags.detail = description.detail
+    tags.cluster = description.clusterName
+    tags.serverGroupName = description.name
+    tags.createdTime = currentTime.toString()
   }
 }
 

--- a/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/Resource.groovy
+++ b/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/Resource.groovy
@@ -61,16 +61,13 @@ class PublicIpResource extends Resource{
   PublicIPProperties properties = new PublicIPProperties()
 
   PublicIpResource() {
+    def currentTime = System.currentTimeMillis()
     apiVersion = "[variables('apiVersion')]"
     name = "[variables('publicIPAddressName')]"
     type = "Microsoft.Network/publicIPAddresses"
     location = "[parameters('location')]"
     tags = [:]
-    tags.appName = description.application
-    tags.stack = description.stack
-    tags.detail = description.detail
-    tags.cluster = description.clusterName
-    tags.serverGroupName = description.name
+    tags.appName = name
     tags.createdTime = currentTime.toString()
   }
 }


### PR DESCRIPTION
Since we are not setting up tags field in publicIPAddresses , the template generate null value , for example

"apiVersion" : "[variables('apiVersion')]",
    "name" : "[variables('publicIPAddressName')]",
    "type" : "Microsoft.Network/publicIPAddresses",
    "location" : "[parameters('location')]",
    "tags" : null,
    "properties" : {
      "publicIPAllocationMethod" : "[variables('publicIPAddressType')]",
      "dnsSettings" : {
        "domainNameLabel" : "[variables('dnsNameForLBIP')]"
      }
    }

I have initialized the tags in the current fix.

We prefer small, well tested pull requests.

Please refer to [Contributing to Spinnaker](https://spinnaker.io/community/contributing/).

When filling out a pull request, please consider the following:

* Follow the commit message conventions [found here](http://www.spinnaker.io/v1.0/docs/how-to-submit-a-patch).
* Provide a descriptive summary for your changes.
* If it fixes a bug or resolves a feature request, be sure to link to that issue.
* Add inline code comments to changes that might not be obvious.
* Squash your commits as you keep adding changes.
* Add a comment to @spinnaker/reviewers for review if your issue has been outstanding for more than 3 days.

Note that we are unlikely to accept pull requests that add features without prior discussion. The best way to propose a feature is to open an issue first and discuss your ideas there before implementing them.
